### PR TITLE
Removed `install:` step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ rvm:
 before_script:
  - chmod +x ./script/cibuild # or do this locally and commit
 
-# Assume bundler is being used, therefore
-# the `install` step will run `bundle install` by default.
-install: gem install jekyll html-proofer
+# Don't provide an `install:` step in order for `bundle install` to be called by default
+
 script: jekyll build && htmlproofer ./_site
 
 # branch whitelist, only for GitHub Pages


### PR DESCRIPTION
Don't provide an `install:` step in order for `bundle install` to be called by default